### PR TITLE
Possible fix to an error in create_game

### DIFF
--- a/assignments/week-02/day-08/README.md
+++ b/assignments/week-02/day-08/README.md
@@ -127,7 +127,7 @@ class InitializedGame:
         self.playerTwoId = playerTwoId
 
 def initialize_game() -> InitializedGame:
-    response = requests.post(config.API_URL + "/create_game")
+    response = requests.post(config.API_URL + "/create_game", json={})
     assert response.status_code == 201
 
     json = response.json()


### PR DESCRIPTION
In acceptance testing, I was getting a 400 response code to the `create_game` POST request in `connect4-server/src/tests/acceptance/helper.py : initialize_game()`

```
400 Bad Request
Bad Request
Did not attempt to load JSON data because the request Content-Type was not application/json.
```

Adding an empty JSON object as a parameter to the `create_game` POST request solved this problem for me (and at least 3 other groups).

Please let me know if this change is helpful or not.